### PR TITLE
Migrate to bevy 0.12.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+Cargo.lock

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,6 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bevy = "0.11.3"
-bevy-inspector-egui = "0.20.0"
+bevy = "0.12.1"
+bevy-inspector-egui = "0.22.1"
 rand = "0.8.5"

--- a/src/landscape.rs
+++ b/src/landscape.rs
@@ -1,10 +1,9 @@
 use bevy::{
     math::vec3,
     prelude::*,
-    reflect::TypeUuid,
     render::{
-        render_resource::{AddressMode, AsBindGroup, SamplerDescriptor, ShaderRef},
-        texture::ImageSampler,
+        render_resource::{AsBindGroup, ShaderRef},
+        texture::{ImageAddressMode, ImageSampler, ImageSamplerDescriptor},
     },
 };
 
@@ -50,15 +49,15 @@ fn set_textures_repeating(
     mut texture_events: EventReader<AssetEvent<Image>>,
     mut textures: ResMut<Assets<Image>>,
 ) {
-    for event in texture_events.iter() {
+    for event in texture_events.read() {
         match event {
-            AssetEvent::Created { handle } => {
-                let Some(texture) = textures.get_mut(handle) else {
+            AssetEvent::Added { id } => {
+                let Some(texture) = textures.get_mut(*id) else {
                     continue;
                 };
-                texture.sampler_descriptor = ImageSampler::Descriptor(SamplerDescriptor {
-                    address_mode_u: AddressMode::Repeat,
-                    address_mode_v: AddressMode::Repeat,
+                texture.sampler = ImageSampler::Descriptor(ImageSamplerDescriptor {
+                    address_mode_u: ImageAddressMode::Repeat,
+                    address_mode_v: ImageAddressMode::Repeat,
                     ..default()
                 });
             }
@@ -102,9 +101,7 @@ pub fn update_time_uniform(mut materials: ResMut<Assets<LandscapeMaterial>>, tim
     }
 }
 
-// This is the struct that will be passed to your shader
-#[derive(Reflect, AsBindGroup, TypeUuid, Debug, Clone)]
-#[uuid = "f690fdae-d598-45ab-8225-97e2a3f056e0"]
+#[derive(Reflect, Asset, AsBindGroup, Debug, Clone)]
 pub struct LandscapeMaterial {
     #[uniform(0)]
     time: f32,

--- a/src/landscape.rs
+++ b/src/landscape.rs
@@ -21,9 +21,14 @@ pub struct LandscapePlugin;
 impl Plugin for LandscapePlugin {
     fn build(&self, app: &mut App) {
         app.add_systems(Startup, setup)
-            .add_systems(Update, update_time_uniform)
-            .add_systems(Update, set_textures_repeating)
-            .add_systems(Update, move_with_landscape)
+            .add_systems(
+                Update,
+                (
+                    update_time_uniform,
+                    set_textures_repeating,
+                    move_with_landscape,
+                ),
+            )
             .add_plugins(MaterialPlugin::<LandscapeMaterial>::default());
     }
 }

--- a/src/laser.rs
+++ b/src/laser.rs
@@ -89,6 +89,7 @@ pub fn shoot_guns(
                     volume: Volume::new_absolute(volume),
                     speed,
                     paused: false,
+                    ..default()
                 },
             },
             Laser { velocity },

--- a/src/main.rs
+++ b/src/main.rs
@@ -175,11 +175,11 @@ pub fn camera_input(
     time: Res<Time>,
 ) {
     for (mut controller, mut transform) in query.iter_mut() {
-        for wheel in mouse_wheel.iter() {
+        for wheel in mouse_wheel.read() {
             controller.zoom += wheel.y;
         }
         if buttons.pressed(MouseButton::Right) {
-            for mouse in mouse_motion.iter() {
+            for mouse in mouse_motion.read() {
                 let delta = mouse.delta * time.delta_seconds() * 0.3;
                 controller.rotation *= Quat::from_euler(EulerRot::XYZ, -delta.y, -delta.x, 0.0);
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,11 +24,16 @@ fn main() {
         .add_plugins(LandscapePlugin)
         .add_plugins(LaserPlugin)
         .add_systems(Startup, setup)
-        .add_systems(Update, animate_light_direction)
-        .add_systems(Update, start_walker_animation)
-        .add_systems(Update, spawn_objects)
-        .add_systems(Update, camera_input)
-        .add_systems(Update, move_plane)
+        .add_systems(
+            Update,
+            (
+                animate_light_direction,
+                start_walker_animation,
+                spawn_objects,
+                camera_input,
+                move_plane,
+            ),
+        )
         .run();
 }
 


### PR DESCRIPTION
I have migrated the wonderful *Not Star Wars* project, which helped me learn a lot of new things, to latest Bevy release, and changed the following:
* wgsl
* egui
* a few other imports
* some code style changes

Interesting observations:
* Slerp now interpolates between rotation somehow too. Xwing now has
*air turbulence*, while it moves on the plane, which looks insanely cool.